### PR TITLE
fix mismatch history version between react router and history

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
-    "history": "^5.0.0",
+    "history": "^4.9.0",
     "immer": "^7.0.7",
     "polished": "^3.6.5",
     "react": "^16.13.1",


### PR DESCRIPTION
Seems like react router 5x version are only compatible with history.4x

You could check the version [here](https://github.com/ReactTraining/react-router/blob/master/package.json)